### PR TITLE
added force option

### DIFF
--- a/lib/rubygems/commands/deep_fetch_command.rb
+++ b/lib/rubygems/commands/deep_fetch_command.rb
@@ -17,6 +17,13 @@ class Gem::Commands::DeepFetchCommand < Gem::Command
     add_clear_sources_option
 
     add_version_option
+
+    add_option('-f', '--force', '--[no-]-force',
+               'Force gems to download, even if installed'
+              ) do |value, options|
+      options[:force] = value
+    end
+
     # TODO add_platform_option
     # TODO add_prerelease_option
   end
@@ -57,7 +64,7 @@ deep_fetch is usefull to examine new packages before installing them.
     action_requests = resolver.resolve;
 
     action_requests.reject do |ar|
-      ar.installed?
+      ar.installed? unless options[:force]
     end.each do |ar|
       spec = ar.spec
       full_spec = spec.spec


### PR DESCRIPTION

The scenario I have is that I want to download a gem with all of it's deep dependencies to a location in order to share them on a mirror, I want to download them regardless of whether or not the host I'm running the command on has the gem installed already - by default this command will not download any dependencies that are already installed.  This PR adds a `--force` option to override this behaviour and *always* download all gems.
