### PR TITLE
enabled platform

### DIFF
--- a/lib/rubygems/commands/deep_fetch_command.rb
+++ b/lib/rubygems/commands/deep_fetch_command.rb
@@ -17,7 +17,7 @@ class Gem::Commands::DeepFetchCommand < Gem::Command
     add_clear_sources_option
 
     add_version_option
-    # TODO add_platform_option
+    add_platform_option
     # TODO add_prerelease_option
   end
 


### PR DESCRIPTION

We need to get dependencies for a different platform, in our case Java... enabling the platform options seems be all that is needed...

I'm not sure why this was commented out in the first place, it seems to work for me.....

```
$ gem deep_fetch jerakia --version 1.2.0 --force --platform java
Downloaded daemons-1.2.4
Fetching: eventmachine-1.2.1-java.gem (100%)
Downloaded eventmachine-1.2.1
Downloaded rack-1.6.5
....etc

$ ls *-java.gem
bcrypt-3.1.11-java.gem		do_sqlite3-0.10.17-java.gem
bcrypt-ruby-3.1.5-java.gem	eventmachine-1.2.1-java.gem
do_jdbc-0.10.17-java.gem	json-1.8.6-java.gem
```

